### PR TITLE
Change Tomato Town to Tomato Temple

### DIFF
--- a/intents/where should i drop.json
+++ b/intents/where should i drop.json
@@ -27,7 +27,7 @@
             "Dusty Divot",
             "Salty Spring",
             "Retail Row",
-            "Tomato Town",
+            "Tomato Temple",
             "Wailing Wood",
             "Lazy Links",
             "Loot Lake",


### PR DESCRIPTION
From today's Fortnite update - Tomato Town has been renamed to Tomato Temple.