### PR TITLE
Removed Loot Lake

### DIFF
--- a/intents/where should i drop.json
+++ b/intents/where should i drop.json
@@ -30,7 +30,6 @@
             "Tomato Town",
             "Wailing Wood",
             "Lazy Links",
-            "Loot Lake",
             "Lucky Landing",
             "Risky Reels"
           ]


### PR DESCRIPTION
Loot Lake has been un-named in the Season 6 update.